### PR TITLE
Fix cluster-init spec in example template

### DIFF
--- a/examples/glusterfs-client.txt
+++ b/examples/glusterfs-client.txt
@@ -7,7 +7,7 @@
         ImageName = cycle.image.centos7
         KeyPairLocation = ~/.ssh/cyclecloud.pem
 
-    [[[cluster-init glusterfs:default:latest]]]
+    [[[cluster-init glusterfs:default:1.0.0]]]
 
     [[[configuration]]]
         run_list = recipe[glusterfs::client]


### PR DESCRIPTION
Cannot select `latest`, as a cluster-init spec.
Changing this to `1.0.0` allows the spec to be selected.